### PR TITLE
Allow communication from services(80) to pod

### DIFF
--- a/test_k8s.yml
+++ b/test_k8s.yml
@@ -53,6 +53,9 @@ spec:
         - podSelector:
             matchLabels:
               role: test-client
+      ports:
+        - protocol: TCP
+          port: 80
 
 ---
 


### PR DESCRIPTION
Allow port 80 to communicate via service to pod
without this configuration the connection might not work. if it is working then there is a problem with network plugin itself.